### PR TITLE
Prevent users from directly upgrading to the latest version

### DIFF
--- a/manual/docker/6.3 upgrade to 7.0.md
+++ b/manual/docker/6.3 upgrade to 7.0.md
@@ -113,6 +113,7 @@ Community Edition：[Download](https://download.seafile.com/d/320e8adf90fa43ad8f
 
 According to the actual situation, modify the `docker-compose.yml`, mainly the following：
 
+* The tag of an image to pull, should be set to the `7.0.5` version instead of `latest`. Direct upgrade to the latest version is currently not supported, due to the dropped support of Python 2 in 7.1 version of the image.
 * The password of MySQL root ( **MYSQL_ROOT_PASSWORD **and **DB_ROOT_PASSWD** ), should be set to the root password above，such as：`db_dev` ;
 * The volume directory of MySQL data ( **volumes **), should be set to the directory after the migration above, such as：`/opt/seafile-mysql/db:/var/lib/mysql` ;
 * The volume directory of Seafile data ( **volumes **)，should be set to the directory of the old container's volume, such as：`/opt/seafile-data:/shared` .


### PR DESCRIPTION
This patch to the documentation is a quick fix to prevent users from having an error when upgrading directly from 6.3.x to 7.1 (or newer) versions of Seafile image. Due to the dropped support of Python 2 in 7.1, trying to upgrade directly will fail. Changing the image tag to 7.0.5, which is the most recent version of 7.0.x branch, prevents that.

Fixes haiwen/seafile#2385