### PR TITLE
Explicitly update mysqlclient with pip

### DIFF
--- a/manual/upgrade/upgrade_notes_for_8.0.x.md
+++ b/manual/upgrade/upgrade_notes_for_8.0.x.md
@@ -16,7 +16,7 @@ Note, you should install Python libraries system wide using root user or sudo mo
 ```sh
 apt-get install libmysqlclient-dev
 
-sudo pip3 install future mysqlclient
+sudo pip3 install -U future mysqlclient
 ```
 
 * For Debian 10


### PR DESCRIPTION
On Ubuntu bionic (18.04) python3.6 is delivered with an outdated
mysqlclient package. It has to be updated manually first, otherwise
seafile 8.x won't work.