### PR TITLE
apache config: fix office preview

### DIFF
--- a/manual/deploy/deploy_with_apache.md
+++ b/manual/deploy/deploy_with_apache.md
@@ -36,6 +36,8 @@ Modify Apache config file:
     DocumentRoot /var/www
     Alias /media  /home/user/haiwen/seafile-server-latest/seahub/media
 
+    AllowEncodedSlashes On
+
     RewriteEngine On
 
     <Location /media>


### PR DESCRIPTION
References:
* https://httpd.apache.org/docs/2.4/en/mod/core.html#allowencodedslashes
* https://forum.seafile.com/t/document-preview-xlsx-with-libreoffice-not-working-but-docx-pdf-md-works/9252/30?u=shoeper
* https://serverfault.com/a/143342