### PR TITLE
Fixing media path in readme

### DIFF
--- a/manual/deploy/deploy_with_nginx.md
+++ b/manual/deploy/deploy_with_nginx.md
@@ -80,7 +80,7 @@ server {
         error_log       /var/log/nginx/seafhttp.error.log;
     }
     location /media {
-        root /home/user/haiwen/seafile-server-latest/seahub;
+        root /opt/seafile/seafile-server-latest/seahub;
     }
 }
 ```


### PR DESCRIPTION
There was a user path configured instead of the recommended `/opt/seafile/` path