### PR TITLE
Add package dependency to debian

### DIFF
--- a/manual/upgrade/upgrade_notes_for_8.0.x.md
+++ b/manual/upgrade/upgrade_notes_for_8.0.x.md
@@ -22,7 +22,7 @@ sudo pip3 install -U future mysqlclient sqlalchemy==1.4.3
 * For Debian 10
 
 ```sh
-apt-get install  default-libmysqlclient-dev 
+apt-get install  python3-dev default-libmysqlclient-dev 
 
 sudo pip3 install future mysqlclient sqlalchemy==1.4.3
 ```


### PR DESCRIPTION
To run pip3 python3-dev package is required
as noticed with centos 7