### PR TITLE
Fixed reference to libmyqlclient-dev

### DIFF
--- a/manual/build_seafile/rpi.md
+++ b/manual/build_seafile/rpi.md
@@ -23,7 +23,7 @@ Requirements:
 
 ```
 sudo apt-get install build-essential
-sudo apt-get install libevent-dev libcurl4-openssl-dev libglib2.0-dev uuid-dev intltool libsqlite3-dev libmysqlclient-dev libarchive-dev libtool libjansson-dev valac libfuse-dev re2c flex python-setuptools cmake
+sudo apt-get install libevent-dev libcurl4-openssl-dev libglib2.0-dev uuid-dev intltool libsqlite3-dev default-libmysqlclient-dev libarchive-dev libtool libjansson-dev valac libfuse-dev re2c flex python-setuptools cmake
 
 ```
 


### PR DESCRIPTION
The lib is renamed in official debian repo and the command will fail if ran as is now with error message:

Package libmysqlclient-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libmariadb-dev-compat:armhf libmariadb-dev:armhf libmariadb-dev-compat libmariadb-dev