### PR TITLE
Add steps to create and use python venv

### DIFF
--- a/manual/start_seafile_at_system_bootup.md
+++ b/manual/start_seafile_at_system_bootup.md
@@ -1,0 +1,665 @@
+# Start Seafile at System Bootup
+
+## For systems running systemd and python virtual environments
+
+* For example Debian 12
+Create systemd service files, change **${seafile_dir}** to your
+**seafile** installation location and **seafile** to user, who runs
+**seafile** (if appropriate). Then you need to reload systemd's daemons:
+**systemctl daemon-reload**.
+
+### Create the script to activate the python virtual environment
+This file goes in the **${seafile_dir}** directory.  Put another way, it does not go in "seafile-server-latest", but the directory above that.  Throughout this manual the examples use /opt/seafile  for this directory, but you might have chosen to use a different directory.
+
+```
+sudo vim /opt/seafile/run_with_venv.sh
+```
+
+The content of the file is:
+
+```
+#!/bin/bash
+# Activate the python virtual environment (venv) before starting one of the seafile scripts
+
+dir_name="$(dirname $0)"
+source "${dir_name}/python-venv/bin/activate"
+script="$1"
+shift 1
+
+echo "${dir_name}/seafile-server-latest/${script}" "$@"
+"${dir_name}/seafile-server-latest/${script}" "$@"
+```
+make this script executable
+```
+sudo chmod 755 /opt/seafile/run_with_venv.sh
+```
+
+### Create systemd service file /etc/systemd/system/seafile.service
+
+```
+sudo vim /etc/systemd/system/seafile.service
+
+```
+
+The content of the file is:
+
+```
+[Unit]
+Description=Seafile
+# add mysql.service or postgresql.service depending on your database to the line below
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=${seafile_dir}/run_with_venv.sh seafile.sh start
+ExecStop=${seafile_dir}/seafile-server-latest/seafile.sh stop
+LimitNOFILE=infinity
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+### Create systemd service file /etc/systemd/system/seahub.service
+
+```
+sudo vim /etc/systemd/system/seahub.service
+
+```
+
+The content of the file is (please dont forget to change it if you want to run fastcgi):
+
+```
+[Unit]
+Description=Seafile hub
+After=network.target seafile.service
+
+[Service]
+Type=forking
+# change start to start-fastcgi if you want to run fastcgi
+ExecStart=${seafile_dir}/run_with_venv.sh seahub.sh start
+ExecStop=${seafile_dir}/seafile-server-latest/seahub.sh stop
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+### Create systemd service file /etc/systemd/system/seafile-client.service (optional)
+The client doesn't require any packages from pip, so this is the same as for systems without pythong virtual environments.  See that section below.
+
+### Enable service start on system boot
+
+```
+sudo systemctl enable seafile.service
+sudo systemctl enable seahub.service
+sudo systemctl enable seafile-client.service   # optional
+```
+
+## For systems running systemd without python virtual environment
+
+* For example Debian 8 through Debian 11, Linux Ubuntu 15.04 and newer
+
+Create systemd service files, change **${seafile_dir}** to your
+**seafile** installation location and **seafile** to user, who runs
+**seafile** (if appropriate). Then you need to reload systemd's daemons:
+**systemctl daemon-reload**.
+
+
+### Create systemd service file /etc/systemd/system/seafile.service
+
+```
+sudo vim /etc/systemd/system/seafile.service
+
+```
+
+The content of the file is:
+
+```
+[Unit]
+Description=Seafile
+# add mysql.service or postgresql.service depending on your database to the line below
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=${seafile_dir}/seafile-server-latest/seafile.sh start
+ExecStop=${seafile_dir}/seafile-server-latest/seafile.sh stop
+LimitNOFILE=infinity
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+### Create systemd service file /etc/systemd/system/seahub.service
+
+```
+sudo vim /etc/systemd/system/seahub.service
+
+```
+
+The content of the file is (please dont forget to change it if you want to run fastcgi):
+
+```
+[Unit]
+Description=Seafile hub
+After=network.target seafile.service
+
+[Service]
+Type=forking
+# change start to start-fastcgi if you want to run fastcgi
+ExecStart=${seafile_dir}/seafile-server-latest/seahub.sh start
+ExecStop=${seafile_dir}/seafile-server-latest/seahub.sh stop
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+### Create systemd service file /etc/systemd/system/seafile-client.service (optional)
+
+You need to create this service file only if you have **seafile**
+console client and you want to run it on system boot.
+
+```
+sudo vim /etc/systemd/system/seafile-client.service
+
+```
+
+The content of the file is:
+
+```
+[Unit]
+Description=Seafile client
+# Uncomment the next line you are running seafile client on the same computer as server
+# After=seafile.service
+# Or the next one in other case
+# After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/seaf-cli start
+ExecStop=/usr/bin/seaf-cli stop
+RemainAfterExit=yes
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+### Enable service start on system boot
+
+```
+sudo systemctl enable seafile.service
+sudo systemctl enable seahub.service
+sudo systemctl enable seafile-client.service   # optional
+
+```
+
+## For systems using another init system than systemd
+
+## Ubuntu 14.10 and older
+
+On Ubuntu without systemd we make use of the
+[/etc/init.d/](https://help.ubuntu.com/community/UbuntuBootupHowto)
+scripts to start seafile/seahub at system boot.
+
+### Create a script **/etc/init.d/seafile-server**
+
+```
+sudo vim /etc/init.d/seafile-server
+
+```
+
+The content of this script is: (You need to modify the value of **user**
+and **seafile_dir** accordingly)
+
+```
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          seafile-server
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Seafile server
+# Description:       Start Seafile server
+### END INIT INFO
+
+# Change the value of "user" to your linux user name
+user=haiwen
+
+# Change the value of "seafile_dir" to your path of seafile installation
+# usually the home directory of $user
+seafile_dir=/data/haiwen
+script_path=${seafile_dir}/seafile-server-latest
+seafile_init_log=${seafile_dir}/logs/seafile.init.log
+seahub_init_log=${seafile_dir}/logs/seahub.init.log
+
+# Change the value of fastcgi to false if fastcgi is not used
+fastcgi=true
+# Set the port of fastcgi, default is 8000. Change it if you need different.
+fastcgi_port=8000
+#
+# Write a polite log message with date and time
+#
+echo -e "\n \n About to perform $1 for seafile at `date -Iseconds` \n " >> ${seafile_init_log}
+echo -e "\n \n About to perform $1 for seahub at `date -Iseconds` \n " >> ${seahub_init_log}
+case "$1" in
+        start)
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+                if [ $fastcgi = true ];
+                then
+                        sudo -u ${user} ${script_path}/seahub.sh ${1}-fastcgi ${fastcgi_port} >> ${seahub_init_log}
+                else
+                        sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                fi
+        ;;
+        restart)
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+                if [ $fastcgi = true ];
+                then
+                        sudo -u ${user} ${script_path}/seahub.sh ${1}-fastcgi ${fastcgi_port} >> ${seahub_init_log}
+                else
+                        sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                fi
+        ;;
+        stop)
+                sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+        ;;
+        *)
+                echo "Usage: /etc/init.d/seafile-server {start|stop|restart}"
+                exit 1
+        ;;
+esac
+
+```
+
+**Note:** If you are using local mysql server, please replace `# Required-Start:    $remote_fs $syslog` with `# Required-Start:    $remote_fs $syslog mysql`.
+
+### Make the seafile-sever script executable
+
+```
+sudo chmod +x /etc/init.d/seafile-server
+
+```
+
+### Add seafile-server to rc.d
+
+```
+sudo update-rc.d seafile-server defaults
+
+```
+
+**Note:** Don't forget to update the value of **script_path** later if you update
+your seafile server.
+
+## Other Debian based Distributions
+
+### Create a script **/etc/init.d/seafile-server**
+
+```
+sudo vim /etc/init.d/seafile-server
+
+```
+
+The content of this script is: (You need to modify the value of **user**
+and **seafile_dir** accordingly)
+
+```
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          seafile-server
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts Seafile Server
+# Description:       starts Seafile Server
+### END INIT INFO
+
+# Change the value of "user" to linux user name who runs seafile
+user=haiwen
+
+# Change the value of "seafile_dir" to your path of seafile installation
+# usually the home directory of $user
+seafile_dir=/data/haiwen
+script_path=${seafile_dir}/seafile-server-latest
+seafile_init_log=${seafile_dir}/logs/seafile.init.log
+seahub_init_log=${seafile_dir}/logs/seahub.init.log
+
+# Change the value of fastcgi to true if fastcgi is to be used
+fastcgi=false
+# Set the port of fastcgi, default is 8000. Change it if you need different.
+fastcgi_port=8000
+
+#
+# Write a polite log message with date and time
+#
+echo -e "\n \n About to perform $1 for seafile at `date -Iseconds` \n " >> ${seafile_init_log}
+echo -e "\n \n About to perform $1 for seahub at `date -Iseconds` \n " >> ${seahub_init_log}
+
+case "$1" in
+        start)
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+                if [ $fastcgi = true ];
+                then
+                        sudo -u ${user} ${script_path}/seahub.sh ${1}-fastcgi ${fastcgi_port} >> ${seahub_init_log}
+                else
+                        sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                fi
+        ;;
+        restart)
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+                if [ $fastcgi = true ];
+                then
+                        sudo -u ${user} ${script_path}/seahub.sh ${1}-fastcgi ${fastcgi_port} >> ${seahub_init_log}
+                else
+                        sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                fi
+        ;;
+        stop)
+                sudo -u ${user} ${script_path}/seahub.sh ${1} >> ${seahub_init_log}
+                sudo -u ${user} ${script_path}/seafile.sh ${1} >> ${seafile_init_log}
+        ;;
+        *)
+                echo "Usage: /etc/init.d/seafile-server {start|stop|restart}"
+                exit 1
+        ;;
+esac
+
+```
+
+**Note**:
+
+1. If you want to start seahub in fastcgi, just change the **fastcgi**
+   variable to **true**
+2. If you deployed Seafile with MySQL, append "mysql" to the
+   Required-Start line:
+
+
+```
+# Required-Start: $local_fs $remote_fs $network mysql
+
+```
+
+### Add Directory for Logfiles
+
+```
+ mkdir /path/to/seafile/dir/logs
+
+```
+
+### Make the seafile-sever script executable
+
+```
+sudo chmod +x /etc/init.d/seafile-server
+
+```
+
+### Add seafile-server to rc.d
+
+```
+sudo update-rc.d seafile-server defaults
+
+```
+
+### Done
+
+Don't forget to update the value of **seafile_dir** later if you update
+your seafile server.
+
+## RHEL/CentOS
+
+On RHEL/CentOS, the script
+[/etc/rc.local](http://www.centos.org/docs/5/html/Installation_Guide-en-US/s1-boot-init-shutdown-run-boot.html)
+is executed by the system at bootup, so we start seafile/seahub there.
+
+* Locate your python executable (python 2.6 or 2.7)
+
+
+```
+which python2.6 # or "which python2.7"
+
+```
+
+* In /etc/rc.local, add the directory of python2.6(2.7) to **PATH**,
+  and add the seafile/seahub start command
+
+
+```
+`
+# Assume the python 2.6(2.7) executable is in "/usr/local/bin"
+PATH=$PATH:/usr/local/bin/
+
+# Change the value of "user" to your linux user name
+user=haiwen
+
+# Change the value of "seafile_dir" to your path of seafile installation
+# usually the home directory of $user
+seafile_dir=/data/haiwen
+script_path=${seafile_dir}/seafile-server-latest
+
+sudo -u ${user} ${script_path}/seafile.sh start > /tmp/seafile.init.log 2>&1
+sudo -u ${user} ${script_path}/seahub.sh start > /tmp/seahub.init.log 2>&1
+
+```
+
+**Note**: If you want to start seahub in fastcgi, just change the
+**"seahub.sh start"** in the last line above to **"seahub.sh
+start-fastcgi"**
+
+* Done. Don't forget to update the value of **seafile_dir** later if
+  you update your seafile server.
+
+## RHEL/CentOS (run as service)
+
+On RHEL/CentOS we make use of the /etc/init.d/ scripts to start
+seafile/seahub at system boot as service.
+
+### Create a file **/etc/sysconfig/seafile**
+
+```
+# Change the value of "user" to your linux user name
+user=haiwen
+
+# Change the value of "seafile_dir" to your path of seafile installation
+# usually the home directory of $user
+seafile_dir=/data/haiwen
+script_path=${seafile_dir}/seafile-server-latest
+seafile_init_log=${seafile_dir}/logs/seafile.init.log
+seahub_init_log=${seafile_dir}/logs/seahub.init.log
+
+# Change the value of fastcgi to true if fastcgi is to be used
+fastcgi=false
+
+# Set the port of fastcgi, default is 8000. Change it if you need different.
+fastcgi_port=8000
+
+```
+
+### Create a script **/etc/init.d/seafile**
+
+```
+#!/bin/bash
+#
+# seafile
+
+#
+# chkconfig: - 68 32
+# description: seafile
+
+# Source function library.
+. /etc/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+if [ -f /etc/sysconfig/seafile ];then
+        . /etc/sysconfig/seafile
+        else
+            echo "Config file /etc/sysconfig/seafile not found! Bye."
+            exit 200
+        fi
+
+RETVAL=0
+
+start() {
+        # Start daemons.
+        echo -n $"Starting seafile: "
+        ulimit -n 30000
+        su - ${user} -c"${script_path}/seafile.sh start >> ${seafile_init_log} 2>&1"
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && touch /var/lock/subsys/seafile
+        return $RETVAL
+}
+
+stop() {
+        echo -n $"Shutting down seafile: "
+        su - ${user} -c"${script_path}/seafile.sh stop >> ${seafile_init_log} 2>&1"
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/seafile
+        return $RETVAL
+}
+
+#
+# Write a polite log message with date and time
+#
+echo -e "\n \n About to perform $1 for seafile at `date -Iseconds` \n " >> ${seafile_init_log}
+
+# See how we were called.
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart|reload)
+        stop
+        start
+        RETVAL=$?
+        ;;
+  *)
+        echo $"Usage: $0 {start|stop|restart}"
+        RETVAL=3
+esac
+
+exit $RETVAL
+
+```
+
+### Create a script **/etc/init.d/seahub**
+
+```
+#!/bin/bash
+#
+# seahub
+
+#
+# chkconfig: - 69 31
+# description: seahub
+
+# Source function library.
+. /etc/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+if [ -f /etc/sysconfig/seafile ];then
+        . /etc/sysconfig/seafile
+        else
+            echo "Config file /etc/sysconfig/seafile not found! Bye."
+            exit 200
+        fi
+
+RETVAL=0
+
+start() {
+        # Start daemons.
+        echo -n $"Starting seahub: "
+        ulimit -n 30000
+        if [  $fastcgi = true ];
+                then
+                su - ${user} -c"${script_path}/seahub.sh start-fastcgi ${fastcgi_port} >> ${seahub_init_log} 2>&1"
+                else
+                su - ${user} -c"${script_path}/seahub.sh start >> ${seahub_init_log} 2>&1"
+                fi
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && touch /var/lock/subsys/seahub
+        return $RETVAL
+}
+
+stop() {
+        echo -n $"Shutting down seahub: "
+        su - ${user} -c"${script_path}/seahub.sh stop >> ${seahub_init_log} 2>&1"
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/seahub
+        return $RETVAL
+}
+
+#
+# Write a polite log message with date and time
+#
+echo -e "\n \n About to perform $1 for seahub at `date -Iseconds` \n " >> ${seahub_init_log}
+
+# See how we were called.
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart|reload)
+        stop
+        start
+        RETVAL=$?
+        ;;
+  *)
+        echo $"Usage: $0 {start|stop|restart}"
+        RETVAL=3
+esac
+
+exit $RETVAL
+
+```
+
+Next, enable services:
+
+```
+chmod 550 /etc/init.d/seafile
+chmod 550 /etc/init.d/seahub
+chkconfig --add seafile
+chkconfig --add seahub
+chkconfig seahub on
+chkconfig seafile on
+
+```
+
+and run:
+
+```
+service seafile start
+service seahub start
+
+```
+
+

--- a/manual/using_mysql.md
+++ b/manual/using_mysql.md
@@ -1,0 +1,420 @@
+# Installation of Seafile Server Community Edition with MySQL/MariaDB
+
+This manual explains how to deploy and run Seafile Server Community Edition (Seafile CE) on a Linux server from a pre-built package using MySQL/MariaDB as database. The deployment has been tested for Debian/Ubuntu and CentOS, but Seafile should also work on other Linux distributions.
+
+**Tip:** If you have little experience with Seafile Server, we recommend that you use an [installation script](https://github.com/haiwen/seafile-server-installer) for deploying Seafile.
+
+## Requirements
+
+Seafile CE for x86 architecture requires a minimum of 2 cores and 2GB RAM.
+
+There is a community-supported package for the installation on Raspberry Pi.
+
+## Setup
+
+
+### Installing and preparing the SQL database
+
+Seafile supports MySQL and MariaDB. We recommend that you use the preferred SQL database management engine included in the package repositories of your distribution. This means:
+
+* CentOS and Debian: MariaDB
+* Ubuntu: MySQL
+
+You can find step-by-step how-tos for installing MySQL and MariaDB in the [tutorials on the Digital Ocean website](https://www.digitalocean.com/community/tutorials).
+
+Seafile uses the mysql_native_password plugin for authentication. The versions of MySQL and MariaDB installed on CentOS 8, Debian 10, and Ubuntu 20.04 use a different authentication plugin by default. It is therefore required to change to authentication plugin to mysql_native_password for the root user prior to the installation of Seafile. The above mentioned tutorials explain how to do it.
+
+### Installing prerequisites
+
+**For Seafile 8.0.x**
+
+```
+# Debian 10
+sudo apt-get update
+sudo apt-get install python3 python3-setuptools python3-pip default-libmysqlclient-dev -y
+
+sudo pip3 install --timeout=3600 Pillow==9.4.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 \
+    django-pylibmc django-simple-captcha python3-ldap mysqlclient
+
+```
+
+```
+# Ubuntu 18.04
+sudo apt-get update
+sudo apt-get install python3 python3-setuptools python3-pip -y
+
+sudo pip3 install --timeout=3600 Pillow==9.4.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 \
+    django-pylibmc django-simple-captcha python3-ldap
+
+```
+
+```
+# Ubuntu 20.04
+sudo apt-get update
+sudo apt-get install python3 python3-setuptools python3-pip libmysqlclient-dev memcached libmemcached-dev -y
+
+sudo pip3 install --timeout=3600 Pillow==9.4.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 \
+    django-pylibmc django-simple-captcha python3-ldap mysqlclient
+```
+
+
+
+```
+# CentOS 8
+sudo yum install python3 python3-setuptools python3-pip python3-devel mysql-devel gcc -y
+
+sudo pip3 install --timeout=3600 Pillow==9.4.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 \
+    django-pylibmc django-simple-captcha python3-ldap mysqlclient
+
+```
+
+**For Seafile 9.0.x**
+
+Note: CentOS 8 is no longer supported.
+
+
+```
+# Ubuntu 20.04 (almost the same for Ubuntu 18.04 and Debian 10)
+sudo apt-get update
+sudo apt-get install -y python3 python3-setuptools python3-pip libmysqlclient-dev
+sudo apt-get install -y memcached libmemcached-dev
+
+sudo pip3 install --timeout=3600 django==3.2.* Pillow==9.4.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 \
+    django-pylibmc django-simple-captcha python3-ldap mysqlclient pycryptodome==3.12.0 cffi==1.14.0 lxml
+```
+
+**For Seafile 10.0.x**
+
+```
+# Ubuntu 22.04 (almost the same for Ubuntu 20.04 and Debian 11, Debian 10)
+sudo apt-get update
+sudo apt-get install -y python3 python3-setuptools python3-pip libmysqlclient-dev
+sudo apt-get install -y memcached libmemcached-dev
+
+sudo pip3 install --timeout=3600 django==3.2.* future==0.18.* mysqlclient==2.1.* \
+    pymysql pillow==9.3.* pylibmc captcha==0.4 markupsafe==2.0.1 jinja2 sqlalchemy==1.4.3 \
+    psd-tools django-pylibmc django_simple_captcha==0.5.* djangosaml2==1.5.* pysaml2==7.2.* pycryptodome==3.16.* cffi==1.15.1 lxml
+
+```
+
+**For Seafile 11.0.x**
+
+```
+# Ubuntu 22.04 (almost the same for Ubuntu 20.04 and Debian 11, Debian 10)
+sudo apt-get update
+sudo apt-get install -y python3 python3-dev python3-setuptools python3-pip libmysqlclient-dev ldap-utils libldap2-dev
+sudo apt-get install -y memcached libmemcached-dev
+
+sudo pip3 install --timeout=3600 django==3.2.* future==0.18.* mysqlclient==2.1.* \
+    pymysql pillow==10.0.* pylibmc captcha==0.4 markupsafe==2.0.1 jinja2 sqlalchemy==2.0.18 \
+    psd-tools django-pylibmc django_simple_captcha==0.5.* djangosaml2==1.5.* pysaml2==7.2.* pycryptodome==3.16.* cffi==1.15.1 lxml python-ldap==3.4.3
+
+```
+
+**For Seafile 11.0.x on Debian 12**
+
+Debian 12 (and most newer distributions) are now discouraging system-wide installation of python modules with pip.  It is preferred now to install modules into a virtual environment which keeps them separate from the files installed by the system package manager, and enables diffeerent versions to be installed for different applications.  With these python virtual environments (venv for short) to work, you have to activate the venv to make the packages installed in it available to the programs you run.  That is done here with "source python-venv/bin/activate".  Also be aware of the changes in the "Start Seafile at System Bootup" section later in this manual.
+
+```
+# Debian 12 (almost the same as Debian 11, but with python virtual environments to keep pip installs from conflicting with apt-get installs)
+sudo apt-get update
+sudo apt-get install -y python3 python3-dev python3-setuptools python3-pip libmariadb-dev-compat ldap-utils libldap2-dev python3.11-venv
+sudo apt-get install -y memcached libmemcached-dev
+
+## The pip installations will be done below, in the python virtual environment section
+```
+
+### Creating the program directory
+
+The standard directory for Seafile's program files is `/opt/seafile`. Create this directory and change into it:
+
+```
+sudo mkdir /opt/seafile
+cd /opt/seafile
+```
+
+The  program directory can be changed. The standard directory `/opt/seafile` is assumed for the rest of this manual. If you decide to put Seafile in another directory, modify the commands accordingly.
+
+### Creating user seafile
+
+It is good practice not to run applications as root. 
+
+Create a new user and follow the instructions on the screen:
+
+```
+sudo adduser seafile
+```
+
+Change ownership of the created directory to the new user:
+
+```
+sudo chown -R seafile: /opt/seafile
+```
+
+All the following steps are done as user seafile.
+
+Change to user seafile:
+
+```
+su seafile
+```
+
+### Create the python virtual environment and install dependencies with pip (Debian 12)
+For newer systems like Debian 12 where we didn't install the depeneencies with pip above, we will install them here.  Older systems can skip this step.
+```
+cd /opt/seafile
+
+# create the vitual environment in the python-venv directory
+python3 -m venv python-venv
+
+# activate the venv
+source python-venv/bin/activate
+# Notice that this will usually change your prompt so you know the venv is active
+
+# install packages into the active venv with pip (sudo isn't needed because this is installing in the venv, not system-wide).
+pip3 install --timeout=3600  django==3.2.* future==0.18.* mysqlclient==2.1.* pymysql pillow==10.0.* pylibmc captcha==0.4 markupsafe==2.0.1 jinja2 sqlalchemy==2.0.18 psd-tools django-pylibmc django_simple_captcha==0.5.* djangosaml2==1.5.* pysaml2==7.2.* pycryptodome==3.16.* cffi==1.15.1 lxml python-ldap==3.4.3
+```
+
+### Downloading the install package
+
+Download the install package from the [download page](https://www.seafile.com/en/download/) on Seafile's website using wget.
+
+We use Seafile CE version 8.0.4 as an example in the rest of this manual.
+
+### Uncompressing the package
+
+The install package is downloaded as a compressed tarball which needs to be uncompressed.
+
+Uncompress the package using tar:
+
+```
+tar xf seafile-server_8.0.4_x86-64.tar.gz
+```
+
+Now you have:
+
+```
+$ tree -L 2
+.
+├── seafile-server-8.0.4
+│   ├── check_init_admin.py
+│   ├── reset-admin.sh
+│   ├── runtime
+│   ├── seaf-fsck.sh
+│   ├── seaf-fuse.sh
+│   ├── seaf-gc.sh
+│   ├── seafile
+│   ├── seafile.sh
+│   ├── seahub
+│   ├── seahub.sh
+│   ├── setup-seafile-mysql.py
+│   ├── setup-seafile-mysql.sh
+│   ├── setup-seafile.sh
+│   ├── sql
+│   └── upgrade
+└── seafile-server_8.0.4_x86-64.tar.gz
+
+```
+
+### Setting up Seafile CE
+
+The install package comes with a script that sets Seafile up for you. Specifically, the script creates the required directories and extracts all files in the right place. It can also create a MySQL user and the three databases that [Seafile's components](../overview/components.md) require :
+
+* ccnet server
+* seafile server
+* seahub
+
+Note: While ccnet server was merged into the seafile-server in Seafile 8.0, the corresponding database is still required for the time being.
+
+Run the script as user seafile:
+
+```
+# For installations using python virtual environment, activate it if it isn't already active
+source python-venv/bin/activate
+
+cd seafile-server-8.0.4
+./setup-seafile-mysql.sh
+
+```
+
+Configure your Seafile Server by specifying the following three parameters:
+
+| Option                | Description                                          | Note                                                         |
+| --------------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| server name           | Name of the Seafile Server                           | 3-15 characters, only English letters, digits and underscore ('\_') are allowed |
+| server's ip or domain | IP address or domain name used by the Seafile Server | Seafile client program will access the server using this address |
+| fileserver port       | TCP port used by the Seafile fileserver              | Default port is 8082, it is recommended to use this port and to only change it if is used by other service |
+
+
+
+In the next step, choose whether to create new databases for Seafile or to use existing databases. The creation of new databases requires the root password for the SQL server. 
+
+![grafik](../images/seafile-setup-database.png)
+
+When choosing "\[1] Create new ccnet/seafile/seahub databases", the script creates these databases and a MySQL user that Seafile Server will use to access them. To this effect, you need to answer these questions:
+
+| Question                        | Description                                                  | Note                                                         |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| mysql server host               | Host address of the MySQL server                             | Default is localhost                                         |
+| mysql server port               | TCP port used by the MySQL server                            | Default port is 3306; almost every MySQL server uses this port |
+| mysql root password             | Password of the MySQL root account                           | The root password is required to create new databases and a MySQL user |
+| mysql user for Seafile          | MySQL user created by the script, used by Seafile's components to access the databases | Default is seafile; the user is created unless it exists     |
+| mysql password for Seafile user | Password for the user above, written in Seafile's config files | Percent sign ('%') is not allowed                            |
+| database name                   | Name of the database used by ccnet                           | Default is "ccnet-db", the database is created if it does not exist |
+| seafile database name           | Name of the database used by Seafile                         | Default is "seafile-db", the database is created if it does not exist |
+| seahub database name            | Name of the database used by seahub                          | Default is "seahub-db", the database is created if it does not exist |
+
+When choosing "\[2] Use existing ccnet/seafile/seahub databases", this are the prompts you need to answer: 
+
+| Question                        | Description                                                  | Note                                                         |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| mysql server host               | Host address of the MySQL server                             | Default is localhost                                         |
+| mysql server port               | TCP port used by MySQL server                                | Default port is 3306; almost every MySQL server uses this port |
+| mysql user for Seafile          | User used by Seafile's components to access the databases    | The user must exists                                         |
+| mysql password for Seafile user | Password for the user above                                  |                                                              |
+| ccnet database name             | Name of the database used by ccnet, default is "ccnet-db"    | The database must exist                                      |
+| seafile database name           | Name of the database used by Seafile, default is "seafile-db" | The database must exist                                      |
+| seahub dabase name              | Name of the database used by Seahub, default is "seahub-db"  | The database must exist                                      |
+
+If the setup is successful, you see the following output:
+
+![grafik](../images/seafile-setup-output.png)
+
+The directory layout then looks as follows:
+
+```sh
+$ tree /opt/seafile -L 2
+seafile
+├── ccnet
+├── conf
+│   └── ccnet.conf
+│   └── gunicorn.conf.py
+│   └── seafdav.conf
+│   └── seafile.conf
+│   └── seahub_settings.py
+├── seafile-data
+│   └── library-template
+├── seafile-server-8.0.4
+│   └── check_init_admin.py
+│   ├── reset-admin.sh
+│   ├── runtime
+│   └── seaf-fsck.sh
+│   └── seaf-gc.sh
+│   ├── seafile
+│   ├── seafile.sh
+│   ├── seahub
+│   ├── seahub.sh
+│   └── setup-seafile-mysql.py
+│   ├── setup-seafile-mysql.sh
+│   └── sql
+│   └── upgrade
+├── seafile-server-latest -> seafile-server-8.0.6
+├── seahub-data
+│   └── avatars
+
+```
+
+The folder `seafile-server-latest` is a symbolic link to the current Seafile Server folder. When later you upgrade to a new version, the upgrade scripts update this link to point to the latest Seafile Server folder.
+
+
+
+Note: If you don't have the root password, you need someone who has the privileges, e.g., the database admin, to create the three databases required by Seafile, as well as a MySQL user who can access the databases. For example, to create three databases `ccnet_db` / `seafile_db` / `seahub_db` for ccnet/seafile/seahub respectively, and a MySQL user "seafile" to access these databases run the following SQL queries:
+
+```
+create database `ccnet_db` character set = 'utf8';
+create database `seafile_db` character set = 'utf8';
+create database `seahub_db` character set = 'utf8';
+
+create user 'seafile'@'localhost' identified by 'seafile';
+
+GRANT ALL PRIVILEGES ON `ccnet_db`.* to `seafile`@localhost;
+GRANT ALL PRIVILEGES ON `seafile_db`.* to `seafile`@localhost;
+GRANT ALL PRIVILEGES ON `seahub_db`.* to `seafile`@localhost;
+
+```
+
+### Tweaking conf files
+
+Seafile's config files as created by the setup script are prepared for Seafile running behind a reverse proxy.
+
+To access Seafile's web interface and to create working sharing links without a reverse proxy, you need to modify two configuration files in `/opt/seafile/conf`:
+
+* seahub_settings.py (if you use 9.0.x): Add port 8000 to the `SERVICE_URL` (i.e., SERVICE_URL = 'http://1.2.3.4:8000/').
+* ccnet.conf (if you use 8.0.x or 7.1.x): Add port 8000 to the `SERVICE_URL` (i.e., SERVICE_URL = http://1.2.3.4:8000/).
+* gunicorn.conf.py: Change the bind to "0.0.0.0:8000" (i.e., bind = "0.0.0.0:8000")
+
+## Starting Seafile Server
+
+Run the following commands in `/opt/seafile-server-latest`:
+
+```
+# For installations using python virtual environment, activate it if it isn't already active
+source python-venv/bin/activate
+
+./seafile.sh start # starts seaf-server
+./seahub.sh start  # starts seahub
+
+```
+
+The first time you start Seahub, the script prompts you to create an admin account for your Seafile Server. Enter the email address of the admin user followed by the password.
+
+Now you can access Seafile via the web interface at the host address and port 8000 (e.g., http://1.2.3.4:8000)
+
+Note: On CentOS, the firewall blocks traffic on port 8000 by default.
+
+
+### Troubleshooting
+
+If seafile.sh and/or seahub.sh fail to run successfully, use `pgrep` to check if seafile/seahub processes are still running:
+
+
+```
+pgrep -f seafile-controller # checks seafile processes
+pgrep -f "seahub" # checks seahub process
+
+```
+
+Use `pkill` to kill the processes:
+
+
+```
+pkill -f seafile-controller
+pkill -f "seahub"
+
+```
+
+## Stopping and Restarting Seafile and Seahub
+
+### Stopping
+
+```
+./seahub.sh stop 	# stops seahub
+./seafile.sh stop 	# stops seaf-server
+
+```
+
+### Restarting
+
+```
+# For installations using python virtual environment, activate it if it isn't already active
+source python-venv/bin/activate
+
+./seafile.sh restart
+./seahub.sh restart
+
+```
+
+## Enabling HTTPS
+
+It is strongly recommended to switch from unencrypted HTTP (via port 8000) to encrypted HTTPS (via port 443).
+
+This manual provides instructions for enabling HTTPS for the two most popular web servers and reverse proxies:
+
+* [Nginx](https://manual.seafile.com/deploy/https_with_nginx/)
+* [Apache](https://manual.seafile.com/deploy/https_with_apache/)
+
+
+## Performance tuning
+
+If you have more than 50 users, we highly recommand you to [add memcached](../deploy/add_memcached.md). This is going to greatly speed up Seahub (the web frontend).  
+


### PR DESCRIPTION
Added some sections to the "Installation with MySQL" and "Start Seafile at System Bootup" sections to cover creating a python virtual environment, and setting up the systemd units to start seafile with that venv.  

Goes with issue #236