### PR TITLE
Update oauth.md with new Google OAUTH  unique identifier claim

### DIFF
--- a/manual/deploy/oauth.md
+++ b/manual/deploy/oauth.md
@@ -125,7 +125,7 @@ OAUTH_SCOPE = [
     "https://www.googleapis.com/auth/userinfo.profile",
 ]
 OAUTH_ATTRIBUTE_MAP = {
-    "id": (True, "uid"),
+    "sub": (True, "uid"),
     "name": (False, "name"),
     "email": (False, "contact_email"),
 }


### PR DESCRIPTION
This PR addresses an issue of an a error `[ERROR] seahub.oauth.views:169 oauth_callback oauth user uid not found.`. 

This error occues when user would configure Seafile according to the example given in "**Sample settings for Google**" on this page.

As per Google's OID documentation, Google has changed their unique identifier from `id` to `sub`.

Source: https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo

This can also be seen in OpenID Configuration URL:  https://accounts.google.com/.well-known/openid-configuration, wherein Google does not even list the `id` claim anymore in `claims_supported`