### PR TITLE
Correct race condition that prevents server from working after reboot

### DIFF
--- a/manual/repo/docker/ce/seafile-server.yml
+++ b/manual/repo/docker/ce/seafile-server.yml
@@ -62,8 +62,10 @@ services:
       caddy: ${SEAFILE_SERVER_PROTOCOL:-http}://${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
       caddy.reverse_proxy: "{{upstreams 80}}"
     depends_on:
-      - db
-      - memcached
+      db:
+        condition: service_healthy
+      memcached:
+        condition: service_started
     networks:
       - seafile-net
 


### PR DESCRIPTION
When Docker is managing the startup of containers, the existing seafile-server.yml is failing to come up properly due to a race condition: the MySQL container is up, but not yet ready to accept connections and it's causing the process in the server container to die.

Since a proper healthcheck already exists in the compose file, this PR adds the correct status check for db and makes the memcached one more verbose in case anyone wants to implement a health check there as well.

Someone should also probably look into making the server more fault tolerant of db errors, but this solves the problem for today.