### PR TITLE
Fixed "/opt/*" to "/opt/seafile/*"

### DIFF
--- a/manual/upgrade/upgrade_docker.md
+++ b/manual/upgrade/upgrade_docker.md
@@ -34,9 +34,9 @@ Download `.env`, `seafile-server.yml` and `caddy.yml`, and modify `.env` file ac
 
     | Variable                        | Description                                                                                                   | Default Value                   |  
     | ------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------- |  
-    | `SEAFILE_VOLUME`                | The volume directory of Seafile data                                                                          | `/opt/seafile-data`             |  
-    | `SEAFILE_MYSQL_VOLUME`          | The volume directory of MySQL data                                                                            | `/opt/seafile-mysql/db`         |  
-    | `SEAFILE_CADDY_VOLUME`          | The volume directory of Caddy data used to store certificates obtained from Let's Encrypt's                    | `/opt/seafile-caddy`            |  
+    | `SEAFILE_VOLUME`                | The volume directory of Seafile data                                                                          | `/opt/seafile/seafile-data`             |  
+    | `SEAFILE_MYSQL_VOLUME`          | The volume directory of MySQL data                                                                            | `/opt/seafile/seafile-mysql/db`         |  
+    | `SEAFILE_CADDY_VOLUME`          | The volume directory of Caddy data used to store certificates obtained from Let's Encrypt's                    | `/opt/seafile/seafile-caddy`            |  
     | `SEAFILE_MYSQL_DB_USER`         | The user of MySQL (`database` - `user` can be found in `conf/seafile.conf`)                                    | `seafile`  |  
     | `SEAFILE_MYSQL_DB_PASSWORD`     | The user `seafile` password of MySQL                                                                          | (required)  |  
     | `SEAFILE_MYSQL_DB_CCNET_DB_NAME`     | The database name of ccnet | `ccnet_db`  |
@@ -57,9 +57,9 @@ Download `.env`, `seafile-server.yml` and `caddy.yml`, and modify `.env` file ac
 
     | Variable                        | Description                                                                                                   | Default Value                   |  
     | ------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------- |  
-    | `SEAFILE_VOLUME`                | The volume directory of Seafile data                                                                          | `/opt/seafile-data`             |  
-    | `SEAFILE_MYSQL_VOLUME`          | The volume directory of MySQL data                                                                            | `/opt/seafile-mysql/db`         |  
-    | `SEAFILE_CADDY_VOLUME`          | The volume directory of Caddy data used to store certificates obtained from Let's Encrypt's                    | `/opt/seafile-caddy`            |  
+    | `SEAFILE_VOLUME`                | The volume directory of Seafile data                                                                          | `/opt/seafile/seafile-data`             |  
+    | `SEAFILE_MYSQL_VOLUME`          | The volume directory of MySQL data                                                                            | `/opt/seafile/seafile-mysql/db`         |  
+    | `SEAFILE_CADDY_VOLUME`          | The volume directory of Caddy data used to store certificates obtained from Let's Encrypt's                    | `/opt/seafile/seafile-caddy`            |  
     | `SEAFILE_ELASTICSEARCH_VOLUME`  | (Only valid for Seafile PE) The volume directory of Elasticsearch data | `/opt/seafile-elasticsearch/data` |   
     | `SEAFILE_MYSQL_DB_USER`         | The user of MySQL (`database` - `user` can be found in `conf/seafile.conf`)                                    | `seafile`  |  
     | `SEAFILE_MYSQL_DB_PASSWORD`     | The user `seafile` password of MySQL                                                                          | (required)  |  


### PR DESCRIPTION
Hi there,

looks like there is a wrong path in the docs. I was astonished about likely changed paths, tried without them and it worked anyway. So I guess this wasn't by intention?

Same would apply to the `.env` file I guess.

Regards
Henri 