### PR TITLE
fix: add missing instruction to get seadoc.yml

### DIFF
--- a/manual/upgrade/upgrade_docker.md
+++ b/manual/upgrade/upgrade_docker.md
@@ -29,6 +29,7 @@ Download `.env`, `seafile-server.yml` and `caddy.yml`, and modify `.env` file ac
     wget -O .env https://manual.seafile.com/12.0/repo/docker/ce/env
     wget https://manual.seafile.com/12.0/repo/docker/ce/seafile-server.yml
     wget https://manual.seafile.com/12.0/repo/docker/caddy.yml
+    wget https://manual.seafile.com/12.0/repo/docker/seadoc.yml
     ```
     The following fields merit particular attention:
 


### PR DESCRIPTION
Current Docker upgrade 11-to-12 instructions are missing the download of seadoc.yml, which results in non-working container setup. This PR addresses it. 
Issue #599 