### PR TITLE
fix: add SEAFILE_SERVER_HOSTNAME as Docker network alias

### DIFF
--- a/manual/repo/docker/caddy.yml
+++ b/manual/repo/docker/caddy.yml
@@ -13,7 +13,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${SEAFILE_CADDY_VOLUME:-/opt/seafile-caddy}:/data/caddy
     networks:
-      - seafile-net
+      seafile-net:
+        aliases:
+          - ${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:2019/metrics || exit 1"]
       start_period: 20s


### PR DESCRIPTION
## Problem

SeaDoc uses `SEAFILE_SERVER_HOSTNAME` to communicate with Seafile through `/seafhttp/files`.

When running the stack locally, this can fail if the configured hostname is not resolvable from inside the Docker network.

For example, using:

```env
SEAFILE_SERVER_HOSTNAME=seafile.home
```

causes SeaDoc to fail when `seafile.home` is not available through DNS inside the Docker network.

## Solution

Add `SEAFILE_SERVER_HOSTNAME` as a network alias for `seafile-net`:

```yaml
networks:
  seafile-net:
    aliases:
      - ${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
```

This makes the configured hostname resolvable directly within the Docker network, keeping SeaDoc → Seafile communication local to Docker.

## Benefits

* Works with hostnames that are not available through external DNS.
* Keeps internal SeaDoc → Seafile traffic within the Docker network.
* Makes local development easier when using custom/local hostnames.
* Still works normally when the hostname is also backed by real DNS.

Closes #682
